### PR TITLE
Add code from the pcouncil.org theme's functions.php file

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -7,7 +7,7 @@
 
 namespace PFMCFS\Post_Type\Actions;
 
-add_action( 'init', __NAMESPACE__ . '\register_post_type', 10, 1 );
+add_action( 'init', __NAMESPACE__ . '\register_post_type', 10 );
 add_action( 'init', __NAMESPACE__ . '\register_taxonomies', 10 );
 
 /**

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Handling for the Actions post type.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\Post_Type\Actions;
+
+add_action( 'init', __NAMESPACE__ . '\register_post_type', 10, 1 );
+add_action( 'init', __NAMESPACE__ . '\register_taxonomies', 10 );
+
+/**
+ * Register the Actions post type.
+ */
+function register_post_type() {
+
+	$labels = array(
+		'name'          => _x( 'Actions', 'Post Type General Name', 'pfmc-feature-set' ),
+		'singular_name' => _x( 'Action', 'Post Type Singular Name', 'pfmc-feature-set' ),
+		'add_new'       => __( 'Add New Action', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Actions', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'description'           => '',
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'show_ui'               => true,
+		'delete_with_user'      => false,
+		'show_in_rest'          => true,
+		'rest_base'             => '',
+		'rest_controller_class' => 'WP_REST_Posts_Controller',
+		'has_archive'           => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'exclude_from_search'   => false,
+		'capability_type'       => 'post',
+		'map_meta_cap'          => true,
+		'hierarchical'          => false,
+		'rewrite'               => array(
+			'slug'       => 'actions',
+			'with_front' => true,
+		),
+		'query_var'             => true,
+		'menu_position'         => 20,
+		'menu_icon'             => 'dashicons-portfolio',
+		'supports'              => array(
+			'title',
+			'editor',
+			'thumbnail',
+		),
+		'taxonomies'            => array(
+			'category',
+			'post_tag',
+		),
+	);
+
+	\register_post_type( 'actions', $args );
+}
+
+/**
+ * Register the Action Types and Action Groupings taxonomies.
+ */
+function register_taxonomies() {
+
+	// Action Types.
+	$labels = array(
+		'name'          => __( 'Action Types', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Action Type', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Action Types', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'action_types',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'action_types',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'action_types', array( 'actions' ), $args );
+
+	// Action Groupings.
+	$labels = array(
+		'name'          => __( 'Action Groupings', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Action Grouping', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Action Groupings', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'action_grouping',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'action_grouping',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'action_grouping', array( 'actions' ), $args );
+}

--- a/includes/council-meetings.php
+++ b/includes/council-meetings.php
@@ -1,0 +1,511 @@
+<?php
+/**
+ * Handling for the Council Meeting post type.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\Post_Type\Council_Meetings;
+
+add_action( 'init', __NAMESPACE__ . '\register_post_type', 10, 1 );
+add_action( 'save_post', __NAMESPACE__ . '\save_council_meeting_meta', 1 );
+add_shortcode( 'council_meeting', __NAMESPACE__ . '\render_council_meeting_shortcode', 10 );
+
+/**
+ * Register the Council Meeting post type.
+ */
+function register_post_type() {
+
+	$labels = array(
+		'name'          => _x( 'Council Meetings', 'Post Type General Name', 'pfmc-feature-set' ),
+		'singular_name' => _x( 'Council Meeting', 'Post Type Singular Name', 'pfmc-feature-set' ),
+		'all_items'     => __( 'All Meetings', 'pfmc-feature-set' ),
+		'add_new'       => __( 'Add New Meeting', 'pfmc-feature-set' ),
+		'add_new_item'  => __( 'Add New Meeting', 'pfmc-feature-set' ),
+		'edit_item'     => __( 'Edit Meeting', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Council Meetings', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'description'           => '',
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'show_ui'               => true,
+		'delete_with_user'      => false,
+		'show_in_rest'          => true,
+		'rest_base'             => '',
+		'rest_controller_class' => 'WP_REST_Posts_Controller',
+		'has_archive'           => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'exclude_from_search'   => false,
+		'capability_type'       => 'post',
+		'map_meta_cap'          => true,
+		'hierarchical'          => false,
+		'rewrite'               => array(
+			'slug'       => 'council_meeting',
+			'with_front' => true,
+		),
+		'query_var'             => true,
+		'menu_position'         => 20,
+		'menu_icon'             => 'dashicons-calendar',
+		'supports'              => array(
+			'title',
+			'editor',
+			'thumbnail',
+			'excerpt',
+		),
+		'taxonomies'            => array(
+			'category',
+			'post_tag',
+		),
+		'template'              => array(
+			array(
+				'core/columns',
+				array(
+					'className' => 'layout-two_one',
+				),
+				array(
+					array(
+						'core/column',
+						array(),
+						array(
+							array(
+								'core/paragraph',
+								array(
+									'placeholder' => 'Location details',
+								),
+							),
+							array(
+								'core/separator',
+								array(
+									'className' => 'is-style-wide',
+								),
+							),
+							array(
+								'core/paragraph',
+								array(
+									'placeholder' => 'About the meeting',
+								),
+							),
+							array(
+								'core/button',
+								array(
+									'className'   => 'is-style-arrow-link',
+									'placeholder' => 'Add public comment text',
+								),
+							),
+						),
+					),
+					array(
+						'core/column',
+						array(),
+						array(
+							array(
+								'core/group',
+								array(
+									'className' => 'block-box',
+								),
+								array(
+									array(
+										'core/heading',
+										array(
+											'level'     => '2',
+											'className' => 'block-box-head',
+											'content'   => 'Key documents',
+										),
+									),
+									array(
+										'happyprime/latest-custom-posts',
+										array(),
+									),
+								),
+							),
+							array(
+								'core/group',
+								array(
+									'className' => 'block-box',
+								),
+								array(
+									array(
+										'core/heading',
+										array(
+											'level'     => '2',
+											'className' => 'block-box-head',
+											'content'   => 'Council Meeting updates',
+										),
+									),
+									array(
+										'happyprime/latest-custom-posts',
+										array(
+											'itemCount' => '10',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		),
+		'register_meta_box_cb'  => __NAMESPACE__ . '\council_meeting_meta',
+	);
+
+	\register_post_type( 'council_meeting', $args );
+}
+
+/**
+ * Adds a metabox to the right sidebar for Council Meeting CPT
+ */
+function council_meeting_meta() {
+	add_meta_box(
+		'council_meeting_start_date',
+		'Meeting Start Date',
+		__NAMESPACE__ . '\council_meeting_start_date',
+		'council_meeting',
+		'side',
+		'high'
+	);
+
+	add_meta_box(
+		'council_meeting_end_date',
+		'Meeting End Date',
+		__NAMESPACE__ . '\council_meeting_end_date',
+		'council_meeting',
+		'side',
+		'high'
+	);
+
+	add_meta_box(
+		'council_meeting_location',
+		'Meeting Location',
+		__NAMESPACE__ . '\council_meeting_location',
+		'council_meeting',
+		'side',
+		'high'
+	);
+
+	add_meta_box(
+		'council_meeting_documents',
+		'Meeting Documents',
+		__NAMESPACE__ . '\council_meeting_documents',
+		'council_meeting',
+		'side',
+		'high'
+	);
+}
+
+/**
+ * Startdate HTML input for meta in Council Meeting CPT
+ *
+ * @param WP_Post $post The post object.
+ */
+function council_meeting_start_date( $post ) {
+	wp_nonce_field( basename( __FILE__ ), 'meeting_meta_fields' );
+	$meeting_start_date = get_post_meta( $post->ID, 'council_meeting_start_date', true );
+
+	// Convert timestamp back to YYYY-MM-DD that the input field expects.
+	if ( '' !== $meeting_start_date ) {
+		$meeting_start_date = date( 'Y-m-d', $meeting_start_date );
+	}
+
+	echo '<input type="date" id="council_meeting_start_date" name="council_meeting_start_date" value="' . esc_attr( $meeting_start_date ) . '" />';
+}
+
+/**
+ * Enddate HTML input for meta in Council Meeting CPT
+ *
+ * @param WP_Post $post The post object.
+ */
+function council_meeting_end_date( $post ) {
+	wp_nonce_field( basename( __FILE__ ), 'meeting_meta_fields' );
+	$meeting_end_date = get_post_meta( $post->ID, 'council_meeting_end_date', true );
+
+	// Convert timestamp back to YYYY-MM-DD that the input field expects.
+	if ( '' !== $meeting_end_date ) {
+		$meeting_end_date = date( 'Y-m-d', $meeting_end_date );
+	}
+
+	echo '<input type="date" id="council_meeting_end_date" name="council_meeting_end_date" value="' . esc_attr( $meeting_end_date ) . '" />';
+}
+
+/**
+ * Location HTML input for meta in Council Meeting CPT
+ *
+ * @param WP_Post $post The post object.
+ */
+function council_meeting_location( $post ) {
+	wp_nonce_field( basename( __FILE__ ), 'meeting_meta_fields' );
+	$meeting_location = get_post_meta( $post->ID, 'council_meeting_location', true );
+	echo '<input type="text" id="council_meeting_location" name="council_meeting_location" value="' . esc_attr( $meeting_location ) . '" />';
+}
+
+/**
+ * HTML input for documents linked to Council Meetings.
+ *
+ * @param WP_Post $post The post object.
+ */
+function council_meeting_documents( $post ) {
+	$documents = get_post_meta( $post->ID, 'council_meeting_documents', true );
+	$count     = 0;
+
+	if ( ! is_array( $documents ) ) {
+		$documents = array();
+	}
+
+	while ( $count < 5 ) {
+		if ( isset( $documents[ $count ] ) ) {
+			$document_title = $documents[ $count ]['title'];
+			$document_url   = $documents[ $count ]['url'];
+		} else {
+			$document_title = '';
+			$document_url   = '';
+		}
+
+		?>
+		<h3>Document <?php echo absint( $count + 1 ); ?></h3>
+		<label>Title: <input type="text" name="council_meeting_documents[<?php echo absint( $count ); ?>][title]" value="<?php echo esc_attr( $document_title ); ?>" /></label><br />
+		<label>URL: <input type="text" name="council_meeting_documents[<?php echo absint( $count ); ?>][url]" value="<?php echo esc_attr( $document_url ); ?>" /></label>
+		<?php
+
+		$count++;
+	}
+}
+
+/**
+ * Save Council Meeting CPT metabox data
+ *
+ * @param int $post_id The ID of the post.
+ */
+function save_council_meeting_meta( $post_id ) {
+	// Return if the user doesn't have edit permissions.
+	if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		return;
+	}
+
+	// Verify this came from the our screen and with proper authorization,
+	// because save_post can be triggered at other times.
+	if ( ! isset( $_POST['meeting_meta_fields'] ) || ! wp_verify_nonce( sanitize_key( $_POST['meeting_meta_fields'] ), basename( __FILE__ ) ) ) {
+		return;
+	}
+
+	// Save the data.
+	if ( isset( $_POST['council_meeting_start_date'] ) && '' !== sanitize_text_field( wp_unslash( $_POST['council_meeting_start_date'] ) ) ) {
+		update_post_meta( $post_id, 'council_meeting_start_date', strtotime( $_POST['council_meeting_start_date'] ) ); // phpcs:ignore
+	} elseif ( isset( $_POST['council_meeting_start_date'] ) ) {
+		delete_post_meta( $post_id, 'council_meeting_start_date' );
+	}
+
+	if ( isset( $_POST['council_meeting_end_date'] ) && '' !== sanitize_text_field( wp_unslash( $_POST['council_meeting_end_date'] ) ) ) {
+		update_post_meta($post_id, 'council_meeting_end_date', strtotime( $_POST['council_meeting_end_date'] ) ); // phpcs:ignore
+	} elseif ( isset( $_POST['council_meeting_end_date'] ) ) {
+		delete_post_meta( $post_id, 'council_meeting_end_date' );
+	}
+
+	if ( isset( $_POST['council_meeting_location'] ) && '' !== sanitize_text_field( wp_unslash( $_POST['council_meeting_location'] ) ) ) {
+		update_post_meta( $post_id, 'council_meeting_location', sanitize_text_field( wp_unslash( $_POST['council_meeting_location'] ) ) );
+	} elseif ( isset( $_POST['council_meeting_location'] ) ) {
+		delete_post_meta( $post_id, 'council_meeting_location' );
+	}
+
+	if ( isset( $_POST['council_meeting_documents'] ) && is_array( $_POST['council_meeting_documents'] ) ) {
+		$store_documents = array();
+		foreach ($_POST['council_meeting_documents'] as $document) { // phpcs:ignore
+			$title = '';
+			$url   = '';
+
+			if ( isset( $document['title'] ) ) {
+				$title = sanitize_text_field( $document['title'] );
+			}
+
+			if ( isset( $document['url'] ) ) {
+				$url = esc_url_raw( $document['url'] );
+			}
+
+			$store_documents[] = array(
+				'title' => $title,
+				'url'   => $url,
+			);
+		}
+		update_post_meta( $post_id, 'council_meeting_documents', $store_documents );
+	}
+}
+
+/**
+ * Retrieve the current council meeting. If there is no current meeting,
+ * retrieve the next upcoming council meeting.
+ *
+ * @return WP_Post|bool A post object containing the meeting. False if no
+ *                      meeting is available.
+ */
+function get_current_council_meeting() {
+	$today = time();
+
+	$current_meeting_args = array(
+		'post_type'      => 'council_meeting',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'order'          => 'ASC',
+		'meta_key'       => 'council_meeting_start_date', // Key to order by.
+		'orderby'        => 'meta_value_num',
+		'meta_query'     => array(
+			array(
+				'key'     => 'council_meeting_start_date',
+				'value'   => $today,
+				'compare' => '<=',
+			),
+			array(
+				'key'     => 'council_meeting_end_date',
+				'value'   => $today,
+				'compare' => '>=',
+			),
+		),
+	);
+
+	$council_meetings = get_posts( $current_meeting_args );
+
+	if ( 0 === count( $council_meetings ) ) {
+		$upcoming_meeting_args = $current_meeting_args;
+
+		$upcoming_meeting_args['meta_query'] = array(
+			array(
+				'key'     => 'council_meeting_start_date',
+				'value'   => $today,
+				'compare' => '>',
+			),
+		);
+
+		$council_meetings = get_posts( $upcoming_meeting_args );
+	}
+
+	if ( 0 === count( $council_meetings ) ) {
+		return false;
+	}
+
+	return $council_meetings[0];
+}
+
+/**
+ * Retrieve the latest past council meeting.
+ *
+ * @return WP_Post|bool A post object containing the meeting. False if no
+ *                      meeting is available.
+ */
+function get_past_council_meeting() {
+	$today = time();
+
+	$past_meeting_args = array(
+		'post_type'      => 'council_meeting',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'order'          => 'DESC',
+		'meta_key'       => 'council_meeting_end_date', // Key to order by.
+		'orderby'        => 'meta_value_num',
+		'meta_query'     => array(
+			array(
+				'key'     => 'council_meeting_end_date',
+				'value'   => $today,
+				'compare' => '<',
+			),
+		),
+	);
+
+	$council_meetings = get_posts( $past_meeting_args );
+
+	if ( 0 === count( $council_meetings ) ) {
+		return false;
+	}
+
+	return $council_meetings[0];
+}
+
+/**
+ * Display the front-end output for the `council_meeting` shortcode.
+ *
+ * @param array $atts A list of attributes passed to the shortcode.
+ *
+ * @return string HTML output.
+ */
+function render_council_meeting_shortcode( $atts ) {
+	$defaults = array(
+		'type' => 'future',
+	);
+
+	$atts = wp_parse_args( $atts, $defaults );
+
+	if ( 'future' === $atts['type'] ) {
+		$meeting = get_current_council_meeting();
+	} elseif ( 'past' === $atts['type'] ) {
+		$meeting = get_past_council_meeting();
+	} else {
+		return ''; // No other types are supported.
+	}
+
+	// There is no meeting to return, output an empty string.
+	if ( ! $meeting ) {
+		return '';
+	}
+
+	$start_date  = get_post_meta( $meeting->ID, 'council_meeting_start_date', true );
+	$end_date    = get_post_meta( $meeting->ID, 'council_meeting_end_date', true );
+	$location    = get_post_meta( $meeting->ID, 'council_meeting_location', true );
+	$documents   = get_post_meta( $meeting->ID, 'council_meeting_documents', true );
+	$description = get_the_excerpt( $meeting );
+	$meeting_url = get_permalink( $meeting->ID );
+	$today       = time();
+
+	if ( 'past' === $atts['type'] ) {
+		$title = 'Previous Council Meeting';
+	} elseif ( 'future' === $atts['type'] ) {
+		if ( $start_date <= $today ) {
+			$title = 'Current Council Meeting';
+		} else {
+			$title = 'Upcoming Council Meeting';
+		}
+	}
+
+	ob_start();
+	?>
+	<div class="block-box">
+		<h2 class="block-box-head"><?php echo esc_html( $title ); ?></h2>
+		<div class="council-meeting-box">
+			<div class="wp-block-button is-style-arrow-link cm-link"><a href="<?php echo esc_url( $meeting_url ); ?>"><?php echo esc_html( date( 'F', $start_date ) ); ?> council meeting</a></div>
+
+			<datetime class="block-date"><?php echo esc_html( date( 'M j', $start_date ) ) . '&ndash;' . esc_html( date( 'j, Y', $end_date ) ); ?></datetime>
+
+			<?php if ( $location ) : ?>
+				<p class="block-location"><?php echo esc_html( $location ); ?></p>
+			<?php endif; ?>
+
+			<?php if ( '' !== $description ) : ?>
+				<p class="block-descr"><?php echo wp_kses_post( $description ); ?></p>
+			<?php endif; ?>
+
+			<?php
+
+			if ( is_array( $documents ) ) {
+				foreach ( $documents as $cnt => $document ) {
+					if ( '' === trim( $document['title'] ) || '' === trim( $document['url'] ) ) {
+						continue;
+					}
+
+					$style_class = 0 === $cnt ? 'is-style-default' : 'is-style-outline';
+					?>
+						<div class="wp-block-button <?php echo $style_class; // phpcs:ignore ?> meeting-document">
+							<a href="<?php echo esc_url( $document['url'] ); ?>" class="wp-block-button__link"><?php echo esc_html( $document['title'] ); ?></a>
+						</div>
+					<?php
+
+				}
+			}
+
+			?>
+		</div>
+	</div>
+
+	<?php
+	$html = ob_get_clean();
+
+	return $html;
+}

--- a/includes/document-revisions.php
+++ b/includes/document-revisions.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Custom handling for the WP Document Revisions plugin.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\WP_Document_Revisions;
+
+add_filter( 'register_post_type_args', __NAMESPACE__ . '\filter_post_type_args', 10, 2 );
+add_action( 'init', __NAMESPACE__ . '\register_categories_for_documents', 11 );
+add_action( 'init', __NAMESPACE__ . '\register_taxonomies', 10 );
+
+/**
+ * Expose the `document` post type in the REST API.
+ *
+ * @param array  $args      Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
+ */
+function filter_post_type_args( $args, $post_type ) {
+	if ( 'document' === $post_type ) {
+		$args['show_in_rest'] = true;
+	}
+
+	return $args;
+}
+
+/**
+ * Register categories for the `document` post type.
+ */
+function register_categories_for_documents() {
+	register_taxonomy_for_object_type( 'category', 'document' );
+}
+
+/**
+ * Register Document Types and Document Groupings taxonomies.
+ */
+function register_taxonomies() {
+
+	// Document Types.
+	$labels = array(
+		'name'          => __( 'Document Types', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Document Type', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Document Types', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'document_types',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'document_types',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'document_types', array( 'document' ), $args );
+
+	// Document Groups.
+	$labels = array(
+		'name'          => __( 'Document Groups', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Document Group', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Document Group', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'document_group',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'document_group',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'document_group', array( 'document' ), $args );
+}

--- a/includes/managed-fisheries.php
+++ b/includes/managed-fisheries.php
@@ -7,7 +7,7 @@
 
 namespace PFMCFS\Post_Type\Managed_Fisheries;
 
-add_action( 'init', __NAMESPACE__ . '\register_post_type', 10, 1 );
+add_action( 'init', __NAMESPACE__ . '\register_post_type', 10 );
 
 /**
  * Register the Managed Fishery post type.

--- a/includes/managed-fisheries.php
+++ b/includes/managed-fisheries.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Handling for the Managed Fishery post type.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\Post_Type\Managed_Fisheries;
+
+add_action( 'init', __NAMESPACE__ . '\register_post_type', 10, 1 );
+
+/**
+ * Register the Managed Fishery post type.
+ */
+function register_post_type() {
+
+	$labels = array(
+		'name'          => _x( 'Managed Fisheries', 'Post Type General Name', 'pfmc-feature-set' ),
+		'singular_name' => _x( 'Managed Fishery', 'Post Type Singular Name', 'pfmc-feature-set' ),
+		'all_items'     => __( 'All Fisheries', 'pfmc-feature-set' ),
+		'add_new'       => __( 'Add New Fishery', 'pfmc-feature-set' ),
+		'add_new_item'  => __( 'Add New Managed Fishery', 'pfmc-feature-set' ),
+		'edit_item'     => __( 'Edit Fishery', 'pfmc-feature-set' ),
+		'view_item'     => __( 'View Managed Fishery', 'pfmc-feature-set' ),
+		'view_items'    => __( 'View Managed Fishery', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Managed Fisheries', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'description'           => '',
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'show_ui'               => true,
+		'delete_with_user'      => false,
+		'show_in_rest'          => true,
+		'rest_base'             => '',
+		'rest_controller_class' => 'WP_REST_Posts_Controller',
+		'has_archive'           => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'exclude_from_search'   => false,
+		'capability_type'       => 'post',
+		'map_meta_cap'          => true,
+		'hierarchical'          => false,
+		'rewrite'               => array(
+			'slug'       => 'managed_fishery',
+			'with_front' => true,
+		),
+		'query_var'             => true,
+		'menu_position'         => 20,
+		'menu_icon'             => 'dashicons-shield',
+		'supports'              => array(
+			'title',
+			'editor',
+			'thumbnail',
+			'excerpt',
+		),
+		'taxonomies'            => array(
+			'category',
+			'post_tag',
+		),
+	);
+
+	\register_post_type( 'managed_fishery', $args );
+}

--- a/includes/shadow-taxonomies.php
+++ b/includes/shadow-taxonomies.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Handling for the shadow taxonomy functionality.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\Shadow_Taxonomies;
+
+add_action( 'init', __NAMESPACE__ . '\register_taxonomies', 10 );
+add_action( 'save_post_managed_fishery', __NAMESPACE__ . '\update_shadow_taxonomy', 10, 2 );
+add_action( 'save_post_council_meeting', __NAMESPACE__ . '\update_shadow_taxonomy', 10, 2 );
+
+/**
+ * Register the Managed Fisheries and Council Meetings shadow taxonomies.
+ *
+ * Thanks to https://ttmm.io/tech/wordpress-shadow-taxonomies/.
+ */
+function register_taxonomies() {
+
+	// Managed Fisheries Connect.
+	$labels = array(
+		'name'          => __( 'Managed Fisheries Connect', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Managed Fishery Connect', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Managed Fisheries Connect', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'managed_fishery_connect',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'managed_fishery_connect',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'managed_fishery_connect', array( 'actions', 'council_meetings', 'document', 'sc_event', 'post' ), $args );
+
+	// Council Meeting Connect.
+	$labels = array(
+		'name'          => __( 'Council Meeting Connect', 'pfmc-feature-set' ),
+		'singular_name' => __( 'Council Meeting Connect', 'pfmc-feature-set' ),
+	);
+
+	$args = array(
+		'label'                 => __( 'Council Meeting Connect', 'pfmc-feature-set' ),
+		'labels'                => $labels,
+		'public'                => true,
+		'publicly_queryable'    => true,
+		'hierarchical'          => true,
+		'show_ui'               => true,
+		'show_in_menu'          => true,
+		'show_in_nav_menus'     => true,
+		'query_var'             => true,
+		'rewrite'               => array(
+			'slug'       => 'council_meeting_connect',
+			'with_front' => true,
+		),
+		'show_admin_column'     => true,
+		'show_in_rest'          => true,
+		'rest_base'             => 'council_meeting_connect',
+		'rest_controller_class' => 'WP_REST_Terms_Controller',
+		'show_in_quick_edit'    => true,
+	);
+
+	register_taxonomy( 'council_meeting_connect', array( 'actions', 'document', 'post', 'sc_event' ), $args );
+}
+
+/**
+ * When a `managed_fishery` or `council_meeting` post is published,
+ * automatically create a term in its respective shadow taxonomy.
+ *
+ * @uses get_term_by()
+ * @uses wp_insert_term()
+ *
+ * @const DOING_AUTOSAVE
+ *
+ * @param int     $post_id The post ID.
+ * @param WP_Post $post    Post object.
+ */
+function update_shadow_taxonomy( $post_id, $post ) {
+
+	// If we're running an auto-save, don't create a term.
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+		return;
+	}
+
+	// Don't create a term the post is not published or it has no title.
+	if ( 'publish' !== $post->post_status || '' === $post->post_title ) {
+		return;
+	}
+
+	// If `post_date` and `post_modified` aren't equal,
+	// don't create a term because this must be an update.
+	if ( $post->post_date !== $post->post_modified ) {
+		return;
+	}
+
+	// Build the shadow taxonomy slug using the post type slug.
+	$taxonomy = "{$post->post_type}_connect";
+
+	// Stop if there is already a term with the same name as this post title.
+	if ( get_term_by( 'name', $post->post_title, $taxonomy ) ) {
+		return;
+	}
+
+	// Create a new term using the title of this post as a name.
+	wp_insert_term( $post->post_title, $taxonomy );
+}

--- a/includes/sugar-calendar.php
+++ b/includes/sugar-calendar.php
@@ -1,0 +1,365 @@
+<?php
+/**
+ * Custom handling of Sugar Calendar plugin.
+ *
+ * @package PFMC_Feature_Set
+ */
+
+namespace PFMCFS\SugarCalendar;
+
+add_action( 'after_setup_theme', __NAMESPACE__ . '\remove_default_shortcode_registration' );
+add_action( 'init', __NAMESPACE__ . '\add_shortcodes' );
+add_filter( 'sc_events_query_clauses', __NAMESPACE__ . '\sugar_calendar_join_by_taxonomy_term', 15, 2 );
+add_action( 'sc_parse_events_query', __NAMESPACE__ . '\sugar_calendar_pre_get_events_by_taxonomy', 15 );
+
+/**
+ * Remove the default shortcode registration provided by the Sugar Calendar plugin.
+ */
+function remove_default_shortcode_registration() {
+	remove_action( 'init', 'sc_add_shortcodes' );
+}
+
+/**
+ * Add a replacement handler for the sc_events_list shortcode and add back
+ * the default handler for the sc_events_calendar shortcode, which does not
+ * require the same adjustments in this theme.
+ */
+function add_shortcodes() {
+	add_shortcode( 'sc_events_list', __NAMESPACE__ . '\display_sc_events_list_shortcode' );
+	add_shortcode( 'sc_events_calendar', 'sc_events_calendar_shortcode' );
+}
+
+/**
+ * Provide a list of custom taxonomies that have registered support
+ * for the sc_event post type.
+ *
+ * @return array A list of taxonomy slugs.
+ */
+function get_custom_calendar_taxonomies() {
+	$available_taxonomies = get_object_taxonomies( 'sc_event' );
+
+	// This is already handled as the "category" attribute in the shortcode by
+	// the core Sugar Calendar plugin code.
+	$key = array_search( 'sc_event_category', $available_taxonomies, true );
+	if ( false !== $key ) {
+		unset( $available_taxonomies[ $key ] );
+	}
+
+	// This would conflict with the "category" attribute and is not supported as
+	// part of the shortcode query.
+	$key = array_search( 'category', $available_taxonomies, true );
+	if ( false !== $key ) {
+		unset( $available_taxonomies[ $key ] );
+	}
+
+	return $available_taxonomies;
+}
+
+/**
+ * Event list shortcode callback.
+ *
+ * This is forked from Sugar Calendar Lite and updated to add rudimentary support
+ * for querying events by custom taxonomy terms.
+ *
+ * @since 1.0.0
+ *
+ * @param array $atts    A list of shortcode attributes.
+ * @param null  $content Content that may appear inside the shortcode. Unused.
+ *
+ * @return string HTML representing the shortcode.
+ */
+function display_sc_events_list_shortcode( $atts, $content = null ) {
+
+	$default_atts = array(
+		'display'         => 'upcoming',
+		'order'           => '',
+		'number'          => '5',
+		'category'        => null,
+		'show_date'       => null,
+		'show_time'       => null,
+		'show_categories' => null,
+		'show_link'       => null,
+	);
+
+	$available_taxonomies = get_custom_calendar_taxonomies();
+
+	foreach ( $available_taxonomies as $taxonomy ) {
+		$default_atts[ $taxonomy ] = null;
+	}
+
+	$atts = shortcode_atts( $default_atts, $atts );
+
+	$display         = esc_attr( $atts['display'] );
+	$order           = esc_attr( $atts['order'] );
+	$number          = esc_attr( $atts['number'] );
+	$show_date       = esc_attr( $atts['show_date'] );
+	$show_time       = esc_attr( $atts['show_time'] );
+	$show_categories = esc_attr( $atts['show_categories'] );
+	$show_link       = esc_attr( $atts['show_link'] );
+
+	$taxonomies = array(
+		'category' => esc_attr( $atts['category'] ),
+	);
+
+	foreach ( $available_taxonomies as $taxonomy ) {
+		if ( isset( $atts[ $taxonomy ] ) ) {
+			$taxonomies[ $taxonomy ] = esc_attr( $atts[ $taxonomy ] );
+		}
+	}
+
+	$args = array(
+		'date'       => $show_date,
+		'time'       => $show_time,
+		'categories' => $show_categories,
+		'link'       => $show_link,
+	);
+
+	return get_events_list( $display, $taxonomies, $number, $args, $order );
+}
+
+/**
+ * Get a formatted list of upcoming or past events from today's date.
+ *
+ * This is forked from Sugar Calendar Lite and updated to add rudimentary support
+ * for querying events by custom taxonomy terms.
+ *
+ * @see sc_events_list_widget
+ *
+ * @since 1.0.0
+ * @param string $display    Whether to display upcoming, past, or all events.
+ * @param array  $taxonomies Taxonomies to use.
+ * @param int    $number     Number of events to display.
+ * @param array  $show       A series of arguments.
+ * @param string $order      The order in which to display events.
+ *
+ * @return string HTML representing a list of events.
+ */
+function get_events_list( $display = 'upcoming', $taxonomies = array(), $number = 5, $show = array(), $order = '' ) {
+
+	// Get today, to query before/after.
+	$today = date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+
+	// Mutate order to uppercase if not empty.
+	if ( ! empty( $order ) ) {
+		$order = strtoupper( $order );
+	} else {
+		$order = ( 'past' === $display )
+			? 'DESC'
+			: 'ASC';
+	}
+
+	// Maybe force a default.
+	if ( ! in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ) {
+		$order = 'ASC';
+	}
+
+	if ( 'upcoming' === $display ) {
+		$args = array(
+			'object_type' => 'post',
+			'status'      => 'publish',
+			'orderby'     => 'start',
+			'order'       => $order,
+			'number'      => $number,
+			'start_query' => array(
+				'inclusive' => true,
+				'after'     => $today,
+			),
+		);
+	} elseif ( 'past' === $display ) {
+		$args = array(
+			'object_type' => 'post',
+			'status'      => 'publish',
+			'orderby'     => 'start',
+			'order'       => $order,
+			'number'      => $number,
+			'start_query' => array(
+				'inclusive' => true,
+				'before'    => $today,
+			),
+		);
+	} else {
+		// All events.
+		$args = array(
+			'object_type' => 'post',
+			'status'      => 'publish',
+			'orderby'     => 'start',
+			'order'       => $order,
+			'number'      => $number,
+		);
+	}
+
+	// Maybe filter by taxonomy term.
+	if ( ! empty( $taxonomies['category'] ) ) {
+		$args[ sugar_calendar_get_calendar_taxonomy_id() ] = $taxonomies['category'];
+		unset( $taxonomies['category'] );
+	}
+
+	foreach ( $taxonomies as $taxonomy => $term ) {
+		$args[ $taxonomy ] = esc_attr( $term );
+	}
+
+	// Query for events.
+	$events = sugar_calendar_get_events( $args );
+
+	// Bail if no events.
+	if ( empty( $events ) ) {
+		return '';
+	}
+
+	// Start an output buffer to store these result.
+	ob_start();
+
+	do_action( 'sc_before_events_list' );
+
+	// Start an unordered list.
+	echo '<ul class="sc_events_list">';
+
+	// Loop through all events.
+	foreach ( $events as $event ) {
+
+		// Get the object ID and use it for the event ID (for back compat).
+		$event_id = $event->object_id;
+
+		echo '<li class="' . esc_attr( str_replace( 'hentry', '', implode( ' ', get_post_class( 'sc_event', $event_id ) ) ) ) . '">';
+
+		do_action( 'sc_before_event_list_item', $event_id );
+
+		echo '<a href="' . esc_url( get_permalink( $event_id ) ) . '" class="sc_event_link">';
+		echo '<span class="sc_event_title">' . wp_kses_post( get_the_title( $event_id ) ) . '</span></a>';
+
+		if ( ! empty( $show['date'] ) ) {
+			echo '<span class="sc_event_date">' . esc_html( sc_get_formatted_date( $event_id ) ) . '</span>';
+		}
+
+		if ( isset( $show['time'] ) && $show['time'] ) {
+			$start_time = sc_get_event_start_time( $event_id );
+			$end_time   = sc_get_event_end_time( $event_id );
+
+			if ( $event->is_all_day() ) {
+				echo '<span class="sc_event_time">' . esc_html__( 'All-day', 'wp-rig' ) . '</span>';
+			} elseif ( $end_time !== $start_time ) {
+				echo '<span class="sc_event_time">' . esc_html( $start_time ) . '&nbsp;&ndash;&nbsp;' . esc_html( $end_time ) . '</span>';
+			} elseif ( ! empty( $start_time ) ) {
+				echo '<span class="sc_event_time">' . esc_html( $start_time ) . '</span>';
+			}
+		}
+
+		if ( ! empty( $show['categories'] ) ) {
+			$event_categories = get_the_terms( $event_id, 'sc_event_category' );
+
+			if ( $event_categories ) {
+				$categories = wp_list_pluck( $event_categories, 'name' );
+				echo '<span class="sc_event_categories">' . esc_html( join( $categories, ', ' ) ) . '</span>';
+			}
+		}
+
+		if ( ! empty( $show['link'] ) ) {
+			echo '<a href="' . esc_url( get_permalink( $event_id ) ) . '" class="sc_event_link">';
+			echo esc_html__( 'Read More', 'wp-rig' );
+			echo '</a>';
+		}
+
+		do_action( 'sc_after_event_list_item', $event_id );
+
+		echo '<br class="clear"></li>';
+	}
+
+	// Close the list.
+	echo '</ul>';
+
+	// Reset post data - we'll be looping through our own.
+	wp_reset_postdata();
+
+	do_action( 'sc_after_events_list' );
+
+	// Return the current buffer and delete it.
+	return ob_get_clean();
+}
+
+/**
+ * Filter events query variables and maybe add the taxonomy and term.
+ *
+ * This filter is necessary to ensure events queries are cached using the
+ * taxonomy and term they are queried by.
+ *
+ * This is forked from Sugar Calendar Lite and updated to add rudimentary support
+ * for querying events by custom taxonomy terms.
+ *
+ * @since 2.0.0
+ *
+ * @param object|Query $query The current query being adjusted.
+ */
+function sugar_calendar_pre_get_events_by_taxonomy( $query ) {
+
+	$available_taxonomies = get_custom_calendar_taxonomies();
+
+	foreach ( $available_taxonomies as $taxonomy ) {
+		if ( isset( $query->query_var_originals[ $taxonomy ] ) ) {
+			$query->set_query_var( $taxonomy, $query->query_var_originals[ $taxonomy ] );
+		}
+	}
+}
+
+/**
+ * Filter events queries and maybe JOIN by taxonomy term relationships
+ *
+ * This is hard-coded (for now) to provide back-compat with the built-in
+ * post-type & taxonomy. It can be expanded to support any/all in future versions.
+ *
+ * This is forked from Sugar Calendar Lite and updated to add rudimentary support
+ * for querying events by custom taxonomy terms.
+ *
+ * @since 2.0.0
+ *
+ * @param array        $clauses Clauses to be used in a query.
+ * @param object|Query $query   The current query being adjusted.
+ *
+ * @return array Clauses to be used in a query.
+ */
+function sugar_calendar_join_by_taxonomy_term( $clauses = array(), $query = false ) {
+
+	$available_taxonomies = get_custom_calendar_taxonomies();
+
+	$join_clauses   = array();
+	$join_clauses[] = $clauses['join'];
+
+	$where_clauses   = array();
+	$where_clauses[] = $clauses['where'];
+
+	$replacement = 1;
+
+	foreach ( $available_taxonomies as $taxonomy ) {
+		if ( isset( $query->query_var_originals[ $taxonomy ] ) ) {
+			$tax_query = new \WP_Tax_Query(
+				array(
+					array(
+						'taxonomy' => $taxonomy,
+						'terms'    => $query->query_var_originals[ $taxonomy ],
+						'field'    => 'slug',
+					),
+				)
+			);
+
+			// Get the clauses as provided by WP_Tax_Query.
+			$sql_clauses = $tax_query->get_sql( 'sc_e', 'object_id' );
+
+			// JOIN the table as wptr(n) to avoid conflicts with other term queries. This is admittedly kind of ugly,
+			// but works around the abilities we have (as I understand them) with the query classes in Sugar Calendar Lite.
+			$join_clause    = str_replace( 'wp_term_relationships ON', 'wp_term_relationships AS wptr' . $replacement . ' ON', $sql_clauses['join'] );
+			$join_clause    = str_replace( 'wp_term_relationships.', 'wptr' . $replacement . '.', $join_clause );
+			$join_clauses[] = $join_clause;
+
+			// As with the JOIN, rename the wp_term_relationship table to wptr(n) in the WHERE clause.
+			$where_clauses[] = str_replace( 'wp_term_relationships', 'wptr' . $replacement, $sql_clauses['where'] );
+
+			// Increment (n) as used in the wptr(n) table name aliases.
+			$replacement++;
+		}
+	}
+
+	// Bring all of the clauses back together as their expected strings.
+	$clauses['join']  = implode( '', array_filter( $join_clauses ) );
+	$clauses['where'] = implode( '', array_filter( $where_clauses ) );
+
+	return $clauses;
+}

--- a/includes/sugar-calendar.php
+++ b/includes/sugar-calendar.php
@@ -7,10 +7,33 @@
 
 namespace PFMCFS\SugarCalendar;
 
+add_filter( 'register_post_type_args', __NAMESPACE__ . '\filter_post_type_args', 10, 2 );
+add_action( 'init', __NAMESPACE__ . '\register_categories_for_events', 11 );
 add_action( 'after_setup_theme', __NAMESPACE__ . '\remove_default_shortcode_registration' );
 add_action( 'init', __NAMESPACE__ . '\add_shortcodes' );
 add_filter( 'sc_events_query_clauses', __NAMESPACE__ . '\sugar_calendar_join_by_taxonomy_term', 15, 2 );
 add_action( 'sc_parse_events_query', __NAMESPACE__ . '\sugar_calendar_pre_get_events_by_taxonomy', 15 );
+
+/**
+ * Expose the `sc_event` post type in the REST API.
+ *
+ * @param array  $args      Array of arguments for registering a post type.
+ * @param string $post_type Post type key.
+ */
+function filter_post_type_args( $args, $post_type ) {
+	if ( 'sc_event' === $post_type ) {
+		$args['show_in_rest'] = true;
+	}
+
+	return $args;
+}
+
+/**
+ * Register categories for the `sc_event` post type.
+ */
+function register_categories_for_events() {
+	register_taxonomy_for_object_type( 'category', 'sc_event' );
+}
 
 /**
  * Remove the default shortcode registration provided by the Sugar Calendar plugin.
@@ -236,7 +259,7 @@ function get_events_list( $display = 'upcoming', $taxonomies = array(), $number 
 			$end_time   = sc_get_event_end_time( $event_id );
 
 			if ( $event->is_all_day() ) {
-				echo '<span class="sc_event_time">' . esc_html__( 'All-day', 'wp-rig' ) . '</span>';
+				echo '<span class="sc_event_time">' . esc_html__( 'All-day', 'pfmc-feature-set' ) . '</span>';
 			} elseif ( $end_time !== $start_time ) {
 				echo '<span class="sc_event_time">' . esc_html( $start_time ) . '&nbsp;&ndash;&nbsp;' . esc_html( $end_time ) . '</span>';
 			} elseif ( ! empty( $start_time ) ) {
@@ -255,7 +278,7 @@ function get_events_list( $display = 'upcoming', $taxonomies = array(), $number 
 
 		if ( ! empty( $show['link'] ) ) {
 			echo '<a href="' . esc_url( get_permalink( $event_id ) ) . '" class="sc_event_link">';
-			echo esc_html__( 'Read More', 'wp-rig' );
+			echo esc_html__( 'Read More', 'pfmc-feature-set' );
 			echo '</a>';
 		}
 

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -33,3 +33,4 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 
 require_once __DIR__ . '/includes/managed-fisheries.php';
 require_once __DIR__ . '/includes/council-meetings.php';
+require_once __DIR__ . '/includes/actions.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -35,3 +35,4 @@ require_once __DIR__ . '/includes/managed-fisheries.php';
 require_once __DIR__ . '/includes/council-meetings.php';
 require_once __DIR__ . '/includes/actions.php';
 require_once __DIR__ . '/includes/shadow-taxonomies.php';
+require_once __DIR__ . '/includes/sugar-calendar.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -34,3 +34,4 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 require_once __DIR__ . '/includes/managed-fisheries.php';
 require_once __DIR__ . '/includes/council-meetings.php';
 require_once __DIR__ . '/includes/actions.php';
+require_once __DIR__ . '/includes/shadow-taxonomies.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -32,3 +32,4 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 }
 
 require_once __DIR__ . '/includes/managed-fisheries.php';
+require_once __DIR__ . '/includes/council-meetings.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -36,3 +36,4 @@ require_once __DIR__ . '/includes/council-meetings.php';
 require_once __DIR__ . '/includes/actions.php';
 require_once __DIR__ . '/includes/shadow-taxonomies.php';
 require_once __DIR__ . '/includes/sugar-calendar.php';
+require_once __DIR__ . '/includes/document-revisions.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -30,3 +30,5 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 
 	return;
 }
+
+require_once __DIR__ . '/includes/managed-fisheries.php';

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: PFMC Feature Set
+ * Plugin URI:  https://github.com/happyprime/pfmc-feature-set
+ * Description: Custom features for the Pacific Fishery Management Council website.
+ * Author:      Happy Prime
+ * Author URI:  https://happyprime.co
+ * Version:     0.1.0
+ *
+ * @package     PFMC_Feature_Set
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+// This plugin, like WordPress, requires PHP 5.6 and higher.
+if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
+	add_action( 'admin_notices', 'pfmcfs_admin_notice' );
+
+	/**
+	 * Display an admin notice if PHP is not 5.6.
+	 */
+	function pfmcfs_admin_notice() {
+		echo '<div class="error"><p>';
+		esc_html_e( 'PFMC Feature Set requires PHP 5.6 to function properly. Please upgrade PHP or deactivate the plugin.', 'pfmc-feature-set' );
+		echo '</p></div>';
+	}
+
+	return;
+}


### PR DESCRIPTION
This copies over the customizations and features that should be in place regardless of which theme is active on the Pacific Fishery Management Council website.

Unsurprisingly, it has a companion pull request at https://github.com/happyprime/pcouncil.org/pull/150.

I think there is an opportunity to consolidate some of the queries in `includes/council-meetings.php`, but that can happen in another PR. I also suspect that the code at https://github.com/happyprime/pfmc-feature-set/pull/1/files#diff-da96ba5ec5d193cfa30ac7c44707c28aR584-R600 may be yielding different results than expected, based on what the function's doc block says.

And just a quick note that we'll need another plugin with a `require_once __DIR__ . '/pfmc-feature-set/pfmc-feature-set.php';` (or some fancier way to manage loading it) in order for this to work in the `mu-plugins` directory.

Edit: This code from @jeremyfelt on another project would be a nicer way to handle loading this plugin - https://github.com/a8cteam51/techdirt/blob/fd982ba1673870eec15e5763b7bd1a2737620859/mu-plugins/index.php