### PR TITLE
Ensure that the alert bar only displays for published alerts

### DIFF
--- a/includes/alert.php
+++ b/includes/alert.php
@@ -167,6 +167,7 @@ function save_post_meta( $post_id, $post ) {
 		|| ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
 		|| wp_is_post_revision( $post_id )
 		|| ( ! isset( $_POST['pfmcfs_alert_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['pfmcfs_alert_nonce'] ) ), 'pfmcfs_check_alert' ) )
+		|| 'publish' !== $post->post_status
 	) {
 		return;
 	}

--- a/includes/alert.php
+++ b/includes/alert.php
@@ -155,12 +155,6 @@ function display_alert_meta_box( $post ) {
  */
 function save_post_meta( $post_id, $post ) {
 
-	// This is temporary and should eventually be removed.
-	if ( 'publish' !== $post->post_status ) {
-		set_transient( 'pfmc_alert_data', 'no alert', 0 );
-		return;
-	}
-
 	/**
 	 * Return early if:
 	 *     the user doesn't have edit permissions;
@@ -206,7 +200,7 @@ function save_post_meta( $post_id, $post ) {
 		update_post_meta( $post_id, '_pfmcfs_alert_display_through', $display_through );
 	}
 
-	set_transient( 'pfmc_alert_data', $alert_data, $expiration );
+	set_transient( get_pfmc_alert_transient_key(), $alert_data, $expiration );
 }
 
 /**
@@ -219,7 +213,7 @@ function display_alert_bar() {
 		return;
 	}
 
-	$alert_data = get_transient( 'pfmc_alert_data' );
+	$alert_data = get_transient( get_pfmc_alert_transient_key() );
 
 	// Query for an alert post if no transient data is available.
 	if ( ! $alert_data ) {
@@ -267,7 +261,7 @@ function display_alert_bar() {
 
 		wp_reset_postdata();
 
-		set_transient( 'pfmc_alert_data', $alert_data, $expiration );
+		set_transient( get_pfmc_alert_transient_key(), $alert_data, $expiration );
 	}
 
 	// Return early if there is no alert data.

--- a/includes/alert.php
+++ b/includes/alert.php
@@ -155,6 +155,12 @@ function display_alert_meta_box( $post ) {
  */
 function save_post_meta( $post_id, $post ) {
 
+	// This is temporary and should eventually be removed.
+	if ( 'publish' !== $post->post_status ) {
+		set_transient( 'pfmc_alert_data', 'no alert', 0 );
+		return;
+	}
+
 	/**
 	 * Return early if:
 	 *     the user doesn't have edit permissions;

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -32,10 +32,12 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
 }
 
 /**
- * Provides a plugin version for use in cache busting.
+ * Provides a versioned transient key for getting and setting alert data.
+ *
+ * @return string Current alert transient key.
  */
-function pfmc_feature_set_version() {
-	return '0.1.0';
+function get_pfmc_alert_transient_key() {
+	return 'pfmc_alert_data_001';
 }
 
 require_once __DIR__ . '/includes/managed-fisheries.php';


### PR DESCRIPTION
This includes some temporary logic for updating the current transient - a draft alert will need to be saved or resaved in order to get things back where they should be.