### PR TITLE
Use `wp_date()` vs `date()` in `sc_events_*` shortcode queries

### DIFF
--- a/includes/sugar-calendar.php
+++ b/includes/sugar-calendar.php
@@ -163,8 +163,9 @@ function display_sc_events_list_shortcode( $atts, $content = null ) {
  */
 function get_events_list( $display = 'upcoming', $taxonomies = array(), $number = 5, $show = array(), $order = '' ) {
 
-	// Get today, to query before/after.
-	$today = date( 'Y-m-d' ); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
+	// Get today, to query before/after. The event date is stored in local time, which
+	// wp_date() provides when no timezone is provided.
+	$today = wp_date( 'Y-m-d' );
 
 	// Mutate order to uppercase if not empty.
 	if ( ! empty( $order ) ) {


### PR DESCRIPTION
The start and end dates attached to events are stored in local time, which is currently PDT for pcouncil.org. Sugar Calendar originally used `date()` to get the current day, but this returns the server time instead, which can be on a different day than local time—likely UTC. This caused events to drop off of the page early, even when they were ongoing.

Switching to `wp_date()` builds a date that accounts for the local timezone and **should** provide a more relevant query argument.