### PR TITLE
Modify timezone used with alert expiration

### DIFF
--- a/includes/alert.php
+++ b/includes/alert.php
@@ -236,7 +236,7 @@ function display_alert_bar() {
 				'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'     => '_pfmcfs_alert_display_through',
-						'value'   => gmdate( 'Y-m-d' ),
+						'value'   => wp_date( 'Y-m-d' ),
 						'compare' => '>=',
 						'type'    => 'DATE',
 					),

--- a/includes/alert.php
+++ b/includes/alert.php
@@ -237,7 +237,7 @@ function display_alert_bar() {
 					array(
 						'key'     => '_pfmcfs_alert_display_through',
 						'value'   => gmdate( 'Y-m-d' ),
-						'compare' => '>',
+						'compare' => '>=',
 						'type'    => 'DATE',
 					),
 				),

--- a/includes/alert.php
+++ b/includes/alert.php
@@ -104,7 +104,7 @@ function display_alert_meta_box( $post ) {
 	$through_default = gmdate( 'Y-m-d' );
 
 	// Set the default "Display alert through" value as one day from now.
-	$through = ( $through ) ? $through : gmdate( 'Y-m-d', strtotime( '+1 day' ) );
+	$through = ( $through ) ? $through : wp_date( 'Y-m-d', strtotime( '+1 day' ) );
 
 	?>
 	<p><?php esc_html_e( 'Alert level', 'pfmc-feature-set' ); ?></p>

--- a/pfmc-feature-set.php
+++ b/pfmc-feature-set.php
@@ -37,7 +37,7 @@ if ( version_compare( PHP_VERSION, '5.6', '<' ) ) {
  * @return string Current alert transient key.
  */
 function get_pfmc_alert_transient_key() {
-	return 'pfmc_alert_data_001';
+	return 'pfmc_alert_data_002';
 }
 
 require_once __DIR__ . '/includes/managed-fisheries.php';


### PR DESCRIPTION
* Make query for the alert inclusive of the current date.
* Use the current day in PDT (or the site's timezone) rather than UTC