### PR TITLE
Fix managed fisheries archives

### DIFF
--- a/includes/shadow-taxonomies.php
+++ b/includes/shadow-taxonomies.php
@@ -10,6 +10,7 @@ namespace PFMCFS\Shadow_Taxonomies;
 add_action( 'init', __NAMESPACE__ . '\register_taxonomies', 10 );
 add_action( 'save_post_managed_fishery', __NAMESPACE__ . '\update_shadow_taxonomy', 10, 2 );
 add_action( 'save_post_council_meeting', __NAMESPACE__ . '\update_shadow_taxonomy', 10, 2 );
+add_filter( 'get_the_archive_title', __NAMESPACE__ . '\filter_managed_fishery_connect_archive_title', 10, 2 );
 
 /**
  * Register the Managed Fisheries and Council Meetings shadow taxonomies.
@@ -117,4 +118,19 @@ function update_shadow_taxonomy( $post_id, $post ) {
 
 	// Create a new term using the title of this post as a name.
 	wp_insert_term( $post->post_title, $taxonomy );
+}
+
+/**
+ * Filter page title on `managed_fishery_connect` taxonomy term archive views.
+ *
+ * @param string $title          Archive title to be displayed.
+ * @param string $original_title Archive title without prefix.
+ * @return string
+ */
+function filter_managed_fishery_connect_archive_title( $title, $original_title ) {
+	if ( is_tax( 'managed_fishery_connect' ) ) {
+		$title = __( 'News & Events: ', 'pfmc-feature-set' ) . $original_title;
+	}
+
+	return $title;
 }

--- a/includes/sugar-calendar.php
+++ b/includes/sugar-calendar.php
@@ -19,6 +19,8 @@ add_action( 'save_post_sc_event', __NAMESPACE__ . '\generate_post', 10, 2 );
 add_action( 'wp_trash_post', __NAMESPACE__ . '\delete_event_generated_post', 10 );
 add_action( 'template_redirect', __NAMESPACE__ . '\redirect_event_generated_posts', 10 );
 add_action( 'pre_get_posts', __NAMESPACE__ . '\filter_managed_fisheries_connect_query', 1000 );
+add_filter( 'the_content', __NAMESPACE__ . '\remove_content_hooks', 9 );
+add_filter( 'the_excerpt', __NAMESPACE__ . '\remove_content_hooks', 9 );
 
 /**
  * Expose the `sc_event` post type in the REST API.
@@ -649,4 +651,18 @@ function filter_managed_fisheries_connect_query( $query ) {
 		remove_filter( 'posts_join', 'sc_modify_events_archive_join', 10, 2 );
 		remove_filter( 'posts_orderby', 'sc_modify_events_archive_orderby', 10, 2 );
 	}
+}
+
+/**
+ * Remove the content and excerpt filter hooks from non-event views.
+ *
+ * @param string $content Content or excerpt of the current post.
+ * @return string
+ */
+function remove_content_hooks( $content ) {
+	if ( ! is_singular( 'sc_event' ) && ! is_post_type_archive( 'sc_event' ) ) {
+		remove_filter( current_filter(), 'sc_event_content_hooks' );
+	}
+
+	return $content;
 }


### PR DESCRIPTION
* Remove sugar calendar content and excerpt hooks from non-event views.
* Filter page title on `managed_fishery_connect` taxonomy term archive views.