### PR TITLE
Modify the expected MIME type information for PPSX files

### DIFF
--- a/includes/media.php
+++ b/includes/media.php
@@ -14,6 +14,7 @@ add_filter( 'upload_mimes', __NAMESPACE__ . '\filter_upload_mimes' );
  */
 function filter_mime_types( $mimes ) {
 	$mimes['xlsm'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+	$mimes['ppsx'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
 	return $mimes;
 }
 
@@ -26,5 +27,7 @@ function filter_mime_types( $mimes ) {
  */
 function filter_upload_mimes( $existing_mimes ) {
 	$existing_mimes['xlsm'] = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+	$existing_mimes['ppsx'] = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
+
 	return $existing_mimes;
 }


### PR DESCRIPTION
A PPSX file being uploaded is reporting that it has a mime type of `application/vnd.openxmlformats-officedocument.presentationml.presentation` rather than the `application/vnd.openxmlformats-officedocument.presentationml.slidesho` WordPress expects.