### PR TITLE
Keep shadow taxonomies in sync

### DIFF
--- a/includes/shadow-taxonomies.php
+++ b/includes/shadow-taxonomies.php
@@ -13,6 +13,8 @@ add_action( 'publish_managed_fishery', __NAMESPACE__ . '\update_shadow_taxonomy'
 add_action( 'publish_council_meeting', __NAMESPACE__ . '\update_shadow_taxonomy', 10, 2 );
 add_action( 'draft_managed_fishery', __NAMESPACE__ . '\remove_shadow_taxonomy', 10, 2 );
 add_action( 'draft_council_meeting', __NAMESPACE__ . '\remove_shadow_taxonomy', 10, 2 );
+add_action( 'trash_managed_fishery', __NAMESPACE__ . '\remove_shadow_taxonomy', 10, 2 );
+add_action( 'trash_council_meeting', __NAMESPACE__ . '\remove_shadow_taxonomy', 10, 2 );
 
 add_filter( 'get_the_archive_title', __NAMESPACE__ . '\filter_managed_fishery_connect_archive_title', 10, 2 );
 add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\enqueue_pinned_term_script' );

--- a/includes/shadow-taxonomies.php
+++ b/includes/shadow-taxonomies.php
@@ -52,8 +52,8 @@ function register_taxonomies() {
 		'publicly_queryable'    => true,
 		'hierarchical'          => true,
 		'show_ui'               => true,
-		'show_in_menu'          => true,
-		'show_in_nav_menus'     => true,
+		'show_in_menu'          => false,
+		'show_in_nav_menus'     => false,
 		'query_var'             => true,
 		'rewrite'               => array(
 			'slug'       => 'managed_fishery_connect',
@@ -81,8 +81,8 @@ function register_taxonomies() {
 		'publicly_queryable'    => true,
 		'hierarchical'          => true,
 		'show_ui'               => true,
-		'show_in_menu'          => true,
-		'show_in_nav_menus'     => true,
+		'show_in_menu'          => false,
+		'show_in_nav_menus'     => false,
 		'query_var'             => true,
 		'rewrite'               => array(
 			'slug'       => 'council_meeting_connect',


### PR DESCRIPTION
Just like the SAFMC updates:

#### Proposed changes
- Add `trash_{post_type}` hooks for removing matching shadow taxonomies when their respective posts are deleted.
- Make the shadow taxonomies unavailable for editing in wp-admin, ensuring they are only added and removed programmatically.

#### Testing
- Pull down the code, then to make it easier to validate, edit `plugins/pfmc-feature-set/includes/shadow-taxonomies.php`: set lines 55, 56, 84, and 85 to `true` instead of `false` temporarily. This will allow you to see the shadow taxonomy terms.
- Publish one of each post type - Managed Fishery, Council Meeting. After publishing, check under one of the other post types to verify the corresponding shadow taxonomy term was created.
- Set your test posts to Draft and verify the corresponding shadow taxonomy term was removed.
- Re-publish the test posts (and verify the terms were re-created), then Trash them and verify the terms were removed.
- Once tested, discard your edits to `shadow-taxonomies.php` as we don't want anyone manually adding or removing terms.